### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,18 @@
+name: Docs
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v2
+
+      - name: Deploy docs
+        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+
+      - name: Run image
+        uses: abatilo/actions-poetry@v2.0.0
+
+      - name: Install nox-poetry
+        run: pip install nox-poetry
+
+      - name: Run tests
+        run: nox

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # borsh-construct
 
+[![Tests](https://github.com/near/borsh-construct-py/workflows/Tests/badge.svg)](https://github.com/near/borsh-construct-py/actions?workflow=Tests)
+[![Docs](https://github.com/near/borsh-construct-pye/workflows/Docs/badge.svg)](https://near.github.io/borsh-construct-py/)
+
 `borsh-construct` is an implementation of the [Borsh](https://borsh.io/) binary serialization format for Python projects.
 
 Borsh stands for Binary Object Representation Serializer for Hashing. It is meant to be used in security-critical projects as it prioritizes consistency, safety, speed, and comes with a strict specification.


### PR DESCRIPTION
This adds CI workflows to run the test suite for every PR, and to update the docs every time there's a push to master.

Once the Docs CI runs successfully for the first time, you'll need to go to https://github.com/near/borsh-construct-py/settings/pages and set the branch to `gh-pages` like below (the gh-pages branch will be created automatically by the CI). This will make the docs visible at https://near.github.io/borsh-construct-py/

![image](https://user-images.githubusercontent.com/24635973/136700346-d7e3b6fb-9a4f-4d2a-a60e-43f059dde96c.png)
